### PR TITLE
[BUG] Fixed issue in the csharp generator 

### DIFF
--- a/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -811,11 +811,15 @@ public class CSharpGenerator implements CodeGenerator
                 indent + "    public void Set%1$s(byte[] src, int srcOffset)\n" +
                 indent + "    {\n" +
                 indent + "        const int length = %2$d;\n" +
-                indent + "        if (srcOffset < 0 || srcOffset > (src.Length - length))\n" +
+                indent + "        if (srcOffset < 0 || srcOffset > src.Length)\n" +
                 indent + "        {\n" +
                 indent + "            throw new IndexOutOfRangeException(\"srcOffset out of range for copy: offset=\" + srcOffset);\n" +
                 indent + "        }\n\n" +
-                indent + "        _buffer.SetBytes(_offset + %3$d, src, srcOffset, length);\n" +
+                indent + "        if (src.Length > length)\n" +
+                indent + "        {\n" +
+                indent + "            throw new ArgumentOutOfRangeException($\"src.Length={src.Length} is too large.\");\n" +
+                indent + "        }\n\n" +
+                indent + "        _buffer.SetBytes(_offset + %3$d, src, srcOffset, src.Length - srcOffset);\n" +
                 indent + "    }\n",
                 propName,
                 fieldLength,


### PR DESCRIPTION
that would generate a function that would reject any srcOffset given to it, and throw an exception. now the function should behave as expected.
for example the generated output would be:
```
 public void SetInstrument(byte[] src, int srcOffset)
        {
        const int length = 32;
        if (srcOffset < 0 || srcOffset > (src.Length - length))
        {
            throw new IndexOutOfRangeException("srcOffset out of range for copy: offset=" + srcOffset);
        }
        _buffer.SetBytes(_offset + 0, src, srcOffset, length);
        }
```
Given byte[] src with length 10 - no matter what srcOffset would be we will throw an IndexOutOfRangeException.
the bug fix changed it to look like this:
```
public void SetInstrument(byte[] src, int srcOffset)
        {
        const int length = 32;
        if (srcOffset < 0 || srcOffset > src.Length)
        {
          throw new IndexOutOfRangeException("srcOffset out of range for copy: offset=" + srcOffset);
        }
        if (src.Length > length)
        {
          throw new ArgumentOutOfRangeException($"src length {src.Length}is too large.");
        }
        _buffer.SetBytes(_offset + 0, src, srcOffset, src.Length - srcOffset);
      }
```